### PR TITLE
new: 画面遷移演出を実装

### DIFF
--- a/Unity.Imagine/Assets/Scripts/Screen.meta
+++ b/Unity.Imagine/Assets/Scripts/Screen.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: c8ef499d6aa3cfe4da78dee2b6820c30
+folderAsset: yes
+timeCreated: 1457404510
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity.Imagine/Assets/Scripts/Screen/Effect.cs
+++ b/Unity.Imagine/Assets/Scripts/Screen/Effect.cs
@@ -1,0 +1,13 @@
+﻿
+using System;
+using System.Collections;
+
+public abstract class Effect {
+  protected static ScreenSequencer sequencer { get { return ScreenSequencer.instance; } }
+
+  public abstract bool IsPlaying();
+  public abstract IEnumerator Sequence(Action action);
+
+  /// <summary> <see cref="UnityEngine.MonoBehaviour.StartCoroutine(IEnumerator)"/> の代替メソッド </summary>
+  protected IEnumerator Coroutine(IEnumerator iterator) { while (iterator.MoveNext()) { yield return null; } }
+}

--- a/Unity.Imagine/Assets/Scripts/Screen/Effect.cs.meta
+++ b/Unity.Imagine/Assets/Scripts/Screen/Effect.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 677152c4b00943c4eb2747f19d407033
+timeCreated: 1457390434
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity.Imagine/Assets/Scripts/Screen/Fade.cs
+++ b/Unity.Imagine/Assets/Scripts/Screen/Fade.cs
@@ -1,0 +1,34 @@
+﻿
+using UnityEngine;
+using System;
+using System.Collections;
+
+public class Fade : Effect {
+  public Fade(float time) : base() { _time = time; }
+
+  enum State { FadeOut, FadeIn, Update, }
+  State _state = State.Update;
+  float _time = 0f;
+
+  public override bool IsPlaying() { return _state != State.Update; }
+
+  public override IEnumerator Sequence(Action action) {
+    _state = State.FadeOut;
+    yield return Coroutine(FadeUpdate(count => count < _time, 0f, 1));
+    action();
+    yield return Coroutine(FadeUpdate(count => count > 0f, _time, -1));
+  }
+
+  IEnumerator FadeUpdate(Func<float, bool> RoopExpression, float count, int sign) {
+    while (RoopExpression(count)) {
+      yield return null;
+      count += Time.deltaTime * sign;
+      ImageUpdate(count);
+    }
+    ++_state;
+  }
+
+  void ImageUpdate(float count) {
+    sequencer.image.color = Color.black * (count / _time);
+  }
+}

--- a/Unity.Imagine/Assets/Scripts/Screen/Fade.cs.meta
+++ b/Unity.Imagine/Assets/Scripts/Screen/Fade.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: c2578bf44ef6dba4ba5016039857b7c1
+timeCreated: 1457390434
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity.Imagine/Assets/Scripts/Screen/ScreenSequencer.cs
+++ b/Unity.Imagine/Assets/Scripts/Screen/ScreenSequencer.cs
@@ -1,0 +1,29 @@
+﻿
+using UnityEngine;
+using UnityEngine.UI;
+using System;
+
+/// <summary> 実行したい処理を与えて画面遷移を行う </summary>
+public class ScreenSequencer : SingletonBehaviour<ScreenSequencer> {
+
+  [SerializeField]
+  [Tooltip("演出に使用するフィルターを指定")]
+  Image _image = null;
+  public Image image { get { return _image; } }
+
+  /// <summary> 再生したい <see cref="Effect"/> クラスを new で設定 </summary>
+  public Effect effect { private get; set; }
+  public bool isEffectPlaying { get { return effect.IsPlaying(); } }
+
+  /// <summary> 画面遷移を開始 </summary>
+  public void SequenceStart(Action action) {
+    if (effect.IsPlaying()) { return; }
+    StartCoroutine(effect.Sequence(action));
+  }
+
+  /// <summary> 実行したい <see cref="Effect"/> を指定、画面遷移を開始 </summary>
+  public void SequenceStart(Action action, Effect effect) {
+    this.effect = effect;
+    SequenceStart(action);
+  }
+}

--- a/Unity.Imagine/Assets/Scripts/Screen/ScreenSequencer.cs.meta
+++ b/Unity.Imagine/Assets/Scripts/Screen/ScreenSequencer.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 62a07240b658c3f4090f4a1bfe762ee7
+timeCreated: 1457404532
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#### 概要
シーン切り替え等で使用できる、画面遷移の演出処理を作成しました

・`ScreenSequencer` クラス：遷移処理の管理を行います
・`Effect` クラス：演出処理の抽象クラスです
・`Fade` クラス：フェードイン、フェードアウトで演出を行います

#### 仕様
`Effect` クラスを継承することで、新規の遷移処理の実装が可能です

#### 使用方法
~~~
void Start() {
  // ２秒かけてフェードアウト、２秒かけてフェードインします
  ScreenSequencer.instance.effect = new Fade(2f);
  ScreenSequencer.instance.SequenceStart(ChangeScene);
}
void ChangeScene() {
  SceneManager.LoadScene("title");
}
~~~
