### PR TITLE
fix: 全ての再生完了まで削除されなかった問題を修正

### DIFF
--- a/Unity.Imagine/Assets/Scripts/Audio/SourceObject.cs
+++ b/Unity.Imagine/Assets/Scripts/Audio/SourceObject.cs
@@ -106,14 +106,19 @@ public class SourceObject : MonoBehaviour {
 
   /// <summary> 再生中でなくなれば、リソースを解放する </summary>
   public IEnumerator AutoRelease() {
-    Func<GameScene> GetActiveScene = () => SceneManager.GetActiveScene().ToGameScene();
-    Func<GameScene, bool> IsChanged = scene => scene != GetActiveScene();
+    Func<GameScene> GetActiveScene =
+      () => SceneManager.GetActiveScene().ToGameScene();
 
     // TIPS:
     // ループ中などで、再生中のままシーンが変わったときの判定用に
     // 開始時のシーン情報を保持しておく
     var current = GetActiveScene();
-    while (IsPlayingWithLoop()) { if (IsChanged(current)) { break; } yield return null; }
-    Refresh();
+    while (IsPlayingWithLoop()) {
+      if (current != GetActiveScene()) { break; }
+      Refresh();
+      yield return null;
+    }
+
+    AllStop();
   }
 }


### PR DESCRIPTION
#### 概要
ループを含めて、全ての再生が完了するまで
`AudioSource` が解放されないようになっていたので修正しました
